### PR TITLE
Add script to remove OID conflict Azure DevOps users

### DIFF
--- a/scripts/Remove-OidConflictUsers.ps1
+++ b/scripts/Remove-OidConflictUsers.ps1
@@ -62,3 +62,5 @@ if (!$DryRun) {
 
 Write-Host ""
 Write-Host "EXECUTION COMPLETED" -ForegroundColor Green
+
+return $oidConflictUsers.value

--- a/scripts/Remove-OidConflictUsers.ps1
+++ b/scripts/Remove-OidConflictUsers.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
   Deletes Azure DevOps users whose principalName contains OIDCONFLICT_UpnReuse_
 .DESCRIPTION
-  A automation script that queries all Azure DevOps users of the given organization whose principalName contains OIDCONFLICT_UpnReuse_ and deletes them.
+  An automation script that queries all Azure DevOps users of the given organization whose principalName contains OIDCONFLICT_UpnReuse_ and deletes them.
   IMPORTANT: The script requires the Azure CLI to be installed on the executing machine
   IMPORTANT: The executing user needs to be a member of the "Project Collection Administrators" group
   For more information see https://learn.microsoft.com/en-sg/answers/questions/5569893/azure-devops-oid-conflict
@@ -28,7 +28,7 @@ PARAM
   [Parameter(Mandatory = $true, Position = 0, HelpMessage = "Name of the Azure DevOps organization")]
  	[string] $OrganizationName
   ,
-  [PARAMETER(Mandatory = $false, Position = 1, HelpMessage = "Force a dry/test run – no data will be deleted; the affected users will be written to the console
+  [Parameter(Mandatory = $false, Position = 1, HelpMessage = "Force a dry/test run – no data will be deleted; the affected users will be written to the console")]
   [switch] $DryRun = $false
 )
 

--- a/scripts/Remove-OidConflictUsers.ps1
+++ b/scripts/Remove-OidConflictUsers.ps1
@@ -26,14 +26,21 @@
 PARAM
 (
   [Parameter(Mandatory = $true, Position = 0, HelpMessage = "Name of the Azure DevOps organization")]
- 	[string] $OrganizationName
+  [string] $OrganizationName
   ,
   [Parameter(Mandatory = $false, Position = 1, HelpMessage = "Force a dry/test run – no data will be deleted; the affected users will be written to the console")]
   [switch] $DryRun = $false
 )
 
-az login
+$null = az account show --output none 2>$null
+if ($LASTEXITCODE -ne 0) {
+  throw "Azure CLI is not authenticated. Run 'az login' before executing this script, or use a non-interactive Azure CLI login method in your automation environment."
+}
+
 $accessToken = (az account get-access-token --query accessToken --output tsv)
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($accessToken)) {
+  throw "Failed to acquire an Azure access token from the current Azure CLI session."
+}
 
 Write-Host "Azure DevOps organization: $OrganizationName" -ForegroundColor Yellow
 
@@ -49,7 +56,7 @@ Write-Host ""
 if (!$DryRun) {
   foreach ($user in $oidConflictUsers.value) {
     Write-Host "Delete/remove user $($user.principalName) ..." -ForegroundColor Yellow
-    $azureDevOpsUser = az devops user remove --user $user.principalName
+    $azureDevOpsUser = az devops user remove --org "https://dev.azure.com/$OrganizationName" --user $user.principalName
   }
 }
 

--- a/scripts/Remove-OidConflictUsers.ps1
+++ b/scripts/Remove-OidConflictUsers.ps1
@@ -1,0 +1,57 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Deletes Azure DevOps users whose principalName contains OIDCONFLICT_UpnReuse_
+.DESCRIPTION
+  A automation script that queries all Azure DevOps users of the given organization whose principalName contains OIDCONFLICT_UpnReuse_ and deletes them.
+  IMPORTANT: The script requires the Azure CLI to be installed on the executing machine
+  IMPORTANT: The executing user needs to be a member of the "Project Collection Administrators" group
+  For more information see https://learn.microsoft.com/en-sg/answers/questions/5569893/azure-devops-oid-conflict
+.PARAMETER OrganizationName
+  Name of the Azure DevOps organization
+.PARAMETER DryRun
+  Force a dry/test run – no data will be deleted; the affected users will be written to the console
+.INPUTS
+  None
+.OUTPUTS
+  List of users to be deleted
+.NOTES
+  Version:              1.0
+  Author:               rufer7
+  Creation Date:        05.05.2026
+  Last Modified Date:   05.05.2026
+  Changelog:
+    - Initial script development
+#>
+PARAM
+(
+  [Parameter(Mandatory = $true, Position = 0, HelpMessage = "Name of the Azure DevOps organization")]
+ 	[string] $OrganizationName
+  ,
+  [PARAMETER(Mandatory = $false, Position = 1, HelpMessage = "Force a dry/test run – no data will be deleted; the affected users will be written to the console
+  [switch] $DryRun = $false
+)
+
+az login
+$accessToken = (az account get-access-token --query accessToken --output tsv)
+
+Write-Host "Azure DevOps organization: $OrganizationName" -ForegroundColor Yellow
+
+$requestBody = @{query = "OIDCONFLICT_UpnReuse_"; subjectKind = @("User")} | ConvertTo-Json
+$response = Invoke-WebRequest -Method POST -Uri https://vssps.dev.azure.com/$OrganizationName/_apis/graph/subjectquery?api-version=7.1-preview.1 -Body $requestBody -Headers @{Authorization = "Bearer $accessToken"} -ContentType "application/json"
+$oidConflictUsers = $response.Content | ConvertFrom-Json
+
+Write-Host ""
+Write-Host "Azure DevOps users to be deleted: $($oidConflictUsers.count)" -ForegroundColor Yellow
+$oidConflictUsers.value | Format-Table -AutoSize -Wrap -Property principalName, mailAddress, originId
+Write-Host ""
+
+if (!$DryRun) {
+  foreach ($user in $oidConflictUsers.value) {
+    Write-Host "Delete/remove user $($user.principalName) ..." -ForegroundColor Yellow
+    $azureDevOpsUser = az devops user remove --user $user.principalName
+  }
+}
+
+Write-Host ""
+Write-Host "EXECUTION COMPLETED" -ForegroundColor Green


### PR DESCRIPTION
This script automates the deletion of Azure DevOps users with principal names containing 'OIDCONFLICT_UpnReuse_'. It includes parameters for organization name and a dry run option.